### PR TITLE
[RHTAP-3026] Adds test groups

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,5 +45,6 @@ module.exports = {
             "expand": true,
             "pageTitle": "Red Hat Trusted Application Pipeline e2e report",
         }],
-    ]
+    ],
+    runner: "groups"
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
+    "jest-runner-groups": "^2.2.0",
     "jest-stare": "^2.5.1",
     "prettier": "^2.5.1",
     "ts-jest": "^29.1.1",

--- a/tests/gpts/github/dotnet.jenkins.test.ts
+++ b/tests/gpts/github/dotnet.jenkins.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_suite_jenkins.ts";
 
+/**
+ * Tests dotnet template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group dotnet
+ * @group github
+ * @group basic
+ */
+
 const dotNetTemplateName = 'dotnet-basic';
 const stringOnRoute =  'Welcome';
 

--- a/tests/gpts/github/dotnet.tekton.test.ts
+++ b/tests/gpts/github/dotnet.tekton.test.ts
@@ -2,6 +2,15 @@ import { gitHubBasicGoldenPathTemplateTests } from "./test-config/github_positiv
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
+/**
+ * Tests dotnet template in GitHub with Tekton
+ * 
+ * @group tekton
+ * @group dotnet
+ * @group github
+ * @group basic
+ */
+
 const dotNetTemplateName = 'dotnet-basic';
 
 const runDotNetBasicTests = () => {

--- a/tests/gpts/github/go.jenkins.test.ts
+++ b/tests/gpts/github/go.jenkins.test.ts
@@ -2,6 +2,15 @@ import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
+/**
+ * Tests Go template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group go
+ * @group github
+ * @group basic
+ */
+
 const golangTemplateName = 'go';
 const stringOnRoute =  'Hello World!';
 

--- a/tests/gpts/github/go.tekton.test.ts
+++ b/tests/gpts/github/go.tekton.test.ts
@@ -4,6 +4,15 @@ import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
 const golangTemplateName = 'go';
 
+/**
+ * Tests Go template in GitHub with Tekton
+ * 
+ * @group tekton
+ * @group go
+ * @group github
+ * @group basic
+ */
+
 const runGolangBasicTests = () => {
     const configuration = loadSoftwareTemplatesTestsGlobals()
 

--- a/tests/gpts/github/nodejs.jenkins.test.ts
+++ b/tests/gpts/github/nodejs.jenkins.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_suite_jenkins.ts";
 
+/**
+ * Tests Nodejs template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group nodejs
+ * @group github
+ * @group basic
+ */
+
 const nodejsTemplateName = 'nodejs';
 const stringOnRoute =  'Hello from Node.js Starter Application!';
 

--- a/tests/gpts/github/nodejs.tekton.test.ts
+++ b/tests/gpts/github/nodejs.tekton.test.ts
@@ -2,6 +2,15 @@ import { gitHubBasicGoldenPathTemplateTests } from "./test-config/github_positiv
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
+/**
+ * Tests Nodejs template in GitHub with Tekton
+ * 
+ * @group tekton
+ * @group nodejs
+ * @group github
+ * @group basic
+ */
+
 const nodejsTemplateName = 'nodejs';
 
 const runNodeJSBasicTests = () => {

--- a/tests/gpts/github/python.jenkins.test.ts
+++ b/tests/gpts/github/python.jenkins.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_suite_jenkins.ts";
 
+/**
+ * Tests Python template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group python
+ * @group github
+ * @group basic
+ */
+
 const pythonTemplateName = 'python';
 const stringOnRoute =  'Hello World!';
 

--- a/tests/gpts/github/python.tekton.test.ts
+++ b/tests/gpts/github/python.tekton.test.ts
@@ -2,6 +2,15 @@ import { gitHubBasicGoldenPathTemplateTests } from "./test-config/github_positiv
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
+/**
+ * Tests Python template in GitHub with Tekton
+ * 
+ * @group tekton
+ * @group python
+ * @group github
+ * @group basic
+ */
+
 const pythonTemplateName = 'python';
 
 const runPythonBasicTests = () => {

--- a/tests/gpts/github/quarkus.jenkins.test.ts
+++ b/tests/gpts/github/quarkus.jenkins.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_suite_jenkins.ts";
 
+/**
+ * Tests Quarkus template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group quarkus
+ * @group github
+ * @group basic
+ */
+
 const quarkusTemplateName = 'java-quarkus';
 const stringOnRoute =  'Congratulations, you have created a new Quarkus cloud application.';
 

--- a/tests/gpts/github/quarkus.tekton.test.ts
+++ b/tests/gpts/github/quarkus.tekton.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { githubSoftwareTemplatesAdvancedScenarios } from "./test-config/github_advanced_scenario.ts";
 
+/**
+ * Tests Quarkus template in Github with Tekton
+ * 
+ * @group tekton
+ * @group quarkus
+ * @group github
+ * @group advanced
+ */
+
 const quarkusTemplateName = 'java-quarkus';
 
 const runQuarkusBasicTests = () => {

--- a/tests/gpts/github/springboot.jenkins.test.ts
+++ b/tests/gpts/github/springboot.jenkins.test.ts
@@ -2,6 +2,15 @@ import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 import { gitHubJenkinsBasicGoldenPathTemplateTests } from "./test-config/github_suite_jenkins.ts";
 
+/**
+ * Tests SpringBoot template in GitHub with Jenkins
+ * 
+ * @group jenkins
+ * @group springboot
+ * @group github
+ * @group basic
+ */
+
 const springBootTemplateName = 'java-springboot';
 const stringOnRoute =  'Hello World!';
 

--- a/tests/gpts/github/springboot.tekton.test.ts
+++ b/tests/gpts/github/springboot.tekton.test.ts
@@ -2,6 +2,15 @@ import { gitHubBasicGoldenPathTemplateTests } from "./test-config/github_positiv
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "./test-config/config.ts";
 
+/**
+ * Tests SpringBoot template in GitHub with Tekton
+ * 
+ * @group tekton
+ * @group springboot
+ * @group github
+ * @group basic
+ */
+
 const springBootTemplateName = 'java-springboot';
 
 const runSpringBootBasicTests = () => {

--- a/tests/gpts/gitlab/dotnet.test.ts
+++ b/tests/gpts/gitlab/dotnet.test.ts
@@ -2,6 +2,15 @@ import { gitLabProviderBasicTests } from "./suites-config/gitlab_positive_suite.
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts";
 
+/**
+ * Tests dotnet template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group dotnet
+ * @group gitlab
+ * @group basic
+ */
+
 const dotNetTemplateName = 'dotnet-basic';
 
 const runDotNetBasicTests = () => {

--- a/tests/gpts/gitlab/go.test.ts
+++ b/tests/gpts/gitlab/go.test.ts
@@ -1,6 +1,16 @@
 import { gitLabProviderBasicTests } from "./suites-config/gitlab_positive_suite.ts";
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts";
+
+/**
+ * Tests Go template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group go
+ * @group gitlab
+ * @group basic
+ */
+
 const golangTemplateName = 'go';
 
 const runGolangBasicTests = () => {

--- a/tests/gpts/gitlab/nodejs.test.ts
+++ b/tests/gpts/gitlab/nodejs.test.ts
@@ -2,6 +2,15 @@ import { gitLabProviderBasicTests } from "./suites-config/gitlab_positive_suite.
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts";
 
+/**
+ * Tests Nodejs template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group nodejs
+ * @group gitlab
+ * @group basic
+ */
+
 const nodejsTemplateName = 'nodejs';
 
 const runNodeJSBasicTests = () => {

--- a/tests/gpts/gitlab/python.test.ts
+++ b/tests/gpts/gitlab/python.test.ts
@@ -2,6 +2,15 @@ import { gitLabProviderBasicTests } from "./suites-config/gitlab_positive_suite.
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts"
 
+/**
+ * Tests Python template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group python
+ * @group gitlab
+ * @group basic
+ */
+
 const pythonTemplateName = 'python';
 
 const runPythonBasicTests = () => {

--- a/tests/gpts/gitlab/quarkus.test.ts
+++ b/tests/gpts/gitlab/quarkus.test.ts
@@ -2,6 +2,15 @@ import { gitLabSoftwareTemplatesAdvancedScenarios } from "./suites-config/gitlab
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts"
 
+/**
+ * Tests Quarkus template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group quarkus
+ * @group gitlab
+ * @group advanced
+ */
+
 const quarkusTemplateName = 'java-quarkus';
 
 const runQuarkusBasicTests = () => {

--- a/tests/gpts/gitlab/springboot.test.ts
+++ b/tests/gpts/gitlab/springboot.test.ts
@@ -2,6 +2,15 @@ import { gitLabProviderBasicTests } from "./suites-config/gitlab_positive_suite.
 import { skipSuite } from "../../test-utils.ts";
 import { loadSoftwareTemplatesTestsGlobals } from "../github/test-config/config.ts";
 
+/**
+ * Tests SpringBoot template in GitLab with Tekton
+ * 
+ * @group tekton
+ * @group springboot
+ * @group gitlab
+ * @group basic
+ */
+
 const springBootTemplateName = 'java-springboot';
 
 const runSpringBootBasicTests = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,6 +5148,11 @@ jest-resolve@^29.7.0:
     resolve.exports "^2.0.0"
     slash "^3.0.0"
 
+jest-runner-groups@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-runner-groups/-/jest-runner-groups-2.2.0.tgz#e8ac453322c1f001086f4ea0299b8c4c5bd89166"
+  integrity sha512-Sp/B9ZX0CDAKa9dIkgH0sGyl2eDuScV4SVvOxqhBMxqWpsNAkmol/C58aTFmPWZj+C0ZTW1r1BSu66MTCN+voA==
+
 jest-runner@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"


### PR DESCRIPTION
This PR adds test groups to make it possible to only run tests in specific group.

Example usage: `yarn test --group=go`.

jest-runner-groups docs: https://www.npmjs.com/package/jest-runner-groups