### PR TITLE
fix the issue that pushing image fail when pipelinerun is triggered from repo rhtap-cli

### DIFF
--- a/integration-tests/scripts/rhtap-e2e-runner.sh
+++ b/integration-tests/scripts/rhtap-e2e-runner.sh
@@ -15,6 +15,15 @@ export OCI_STORAGE_USERNAME="$(jq -r '."quay-username"' /usr/local/konflux-test-
 export APPLICATION_ROOT_NAMESPACE="rhtap-app"
 export GITHUB_ORGANIZATION="rhtap-rhdh-qe"
 export GITLAB_ORGANIZATION="rhtap-qe"
+
+#TODO: This is a temporary workaround. We need to find a way to get the git repository name from the pipeline
+#when the pipeline is triggered from the rhtap-cli repository, which is a full installation of the rhtap-cli, the image should be pushed to the rhtap organization
+#otherwise, the image should be pushed to the rhtap_qe organization
+if [ "$GIT_REPO" = "rhtap-cli" ]; then
+    export QUAY_IMAGE_ORG="rhtap"
+else
+    export QUAY_IMAGE_ORG="rhtap_qe"
+fi
 export QUAY_IMAGE_ORG="rhtap_qe"
 export IMAGE_REGISTRY="$(kubectl -n rhtap-quay get route rhtap-quay-quay -o 'jsonpath={.spec.host}')"
 export OCI_CONTAINER="${OCI_CONTAINER:-""}"


### PR DESCRIPTION
This PR is to fix the following issue when pipeline is triggered from repo rhtap-cli 
```
Copying blob sha256:73bce9a35bf11869827a1afc9b7ff838b6c75ea962887a4f4bb08c80a40c1bf8
Copying blob sha256:969795712c492f0c43031ce89dfb3d6ca2c08221fc28fb4479c7e0a370af7342
Error: pushing image "rhtap-quay-quay-rhtap-quay.apps.rosa.kx-9d053930b4.6kgv.p3.openshiftapps.com/rhtap_qe/rhtap-qe:on-pr-bedd1c8fc65355216c95c2080a1d0a3447839ab4" to "docker://rhtap-quay-quay-rhtap-quay.apps.rosa.kx-9d053930b4.6kgv.p3.openshiftapps.com/rhtap_qe/rhtap-qe:on-pr-bedd1c8fc65355216c95c2080a1d0a3447839ab4": trying to reuse blob sha256:969795712c492f0c43031ce89dfb3d6ca2c08221fc28fb4479c7e0a370af7342 at destination: checking whether a blob sha256:969795712c492f0c43031ce89dfb3d6ca2c08221fc28fb4479c7e0a370af7342 exists in rhtap-quay-quay-rhtap-quay.apps.rosa.kx-9d053930b4.6kgv.p3.openshiftapps.com/rhtap_qe/rhtap-qe: authentication required
```