### PR TITLE
[RHTAP-3262] Adds GITOPS_CREDENTIALS to Jenkins job configuration

### DIFF
--- a/src/apis/ci/jenkins.ts
+++ b/src/apis/ci/jenkins.ts
@@ -53,6 +53,7 @@ export class JenkinsCI extends Utils {
                     <userRemoteConfigs>
                         <hudson.plugins.git.UserRemoteConfig>
                             <url>https://${gitProvider}/${organization}/${jobName}</url>
+                            <credentialsId>GITOPS_CREDENTIALS</credentialsId>
                         </hudson.plugins.git.UserRemoteConfig>
                     </userRemoteConfigs>
                     <branches>
@@ -206,10 +207,10 @@ export class JenkinsCI extends Utils {
 
     public async deleteJenkinsJob(jobName: string) {
         const url = `${this.jenkinsUrl}/job/${jobName}/doDelete`;
-    
+
         try {
             const response = await this.axiosInstance.post(url);
-    
+
             if (response.status === 200) {
                 console.log(`Job '${jobName}' deleted successfully.`);
             } else {


### PR DESCRIPTION
This PR adds GitOps credentials to Jenkins job configuration.

Issue: [RHTAP-3262](https://issues.redhat.com/browse/RHTAP-3262)

[PR](https://github.com/redhat-appstudio/rhtap-utils/pull/24/commits/c3f84bb724c692aa00595dab4fdb50c44e8493e3) to add GITOPS_CREDENTIALS to jenkins-credentials script.