### PR TITLE
Minor jenkins tests improvements

### DIFF
--- a/src/utils/argocd.ts
+++ b/src/utils/argocd.ts
@@ -37,17 +37,23 @@ export const syncArgoApplication = async (namespace: string, applicationName: st
     `;
 
     // Execute the shell script commands
-    exec(scriptCommands, (error, stdout: any, stderr: any) => {
-        if (error) {
-            console.error(`Error executing commands: ${error.message}`);
-            return;
-        }
-        if (stderr) {
-            console.error(`Commands STDERR: ${stderr}`);
-            return;
-        }
-
-        console.log(`succesfully synced application ${applicationName} in cluster`);
-        console.log(stdout)
-    });
+    try {
+        await new Promise<void>((done, failed) => {
+            exec(scriptCommands, (error, stdout: any, stderr: any) => {
+                if (error) {
+                    console.error(`Error executing commands: ${error.message}`);
+                    failed(error);
+                }
+                if (stderr) {
+                    console.error(`Commands STDERR: ${stderr}`);
+                }
+        
+                console.log(`succesfully synced application ${applicationName} in cluster`);
+                console.log(stdout);
+                done()
+            });
+        })
+    } catch (error) {
+        fail(error)
+    }
 }

--- a/tests/gpts/github/test-config/github_suite_jenkins.ts
+++ b/tests/gpts/github/test-config/github_suite_jenkins.ts
@@ -143,10 +143,10 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 240000);
+            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 540000);
             expect(jobStatus).not.toBe(undefined);
             expect(jobStatus).toBe("SUCCESS");
-        }, 300000);
+        }, 600000);
 
         /**
          * Creates an empty commit
@@ -164,10 +164,10 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 240000);
+            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 540000);
             expect(jobStatus).not.toBe(undefined);
             expect(jobStatus).toBe("SUCCESS");
-        }, 300000);
+        }, 600000);
 
         /**
          * Obtain the openshift Route for the component and verify that the previous builded image was synced in the cluster and deployed in development environment

--- a/tests/gpts/github/test-config/github_suite_jenkins.ts
+++ b/tests/gpts/github/test-config/github_suite_jenkins.ts
@@ -21,7 +21,6 @@ import { syncArgoApplication } from '../../../../src/utils/argocd';
  */
 export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, stringOnRoute: string) => {
     describe(`Red Hat Trusted Application Pipeline ${gptTemplate} GPT tests GitHub provider with public/private image registry`, () => {
-        jest.retryTimes(2);
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
         const developmentNamespace = `${componentRootNamespace}-development`;
@@ -144,10 +143,10 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 1);
+            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 240000);
             expect(jobStatus).not.toBe(undefined);
             expect(jobStatus).toBe("SUCCESS");
-        }, 240000);
+        }, 300000);
 
         /**
          * Creates an empty commit
@@ -165,10 +164,10 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 2);
+            const jobStatus = await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 240000);
             expect(jobStatus).not.toBe(undefined);
             expect(jobStatus).toBe("SUCCESS");
-        }, 240000);
+        }, 300000);
 
         /**
          * Obtain the openshift Route for the component and verify that the previous builded image was synced in the cluster and deployed in development environment

--- a/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
@@ -23,7 +23,6 @@ import { JenkinsCI } from "../../../../src/apis/ci/jenkins";
  */
 export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRoute: string) => {
     describe(`Red Hat Trusted Application Pipeline ${softwareTemplateName} GPT tests GitLab provider with public/private image registry`, () => {
-        jest.retryTimes(2);
 
         let backstageClient: DeveloperHubClient;
         let developerHubTask: TaskIdReponse;
@@ -134,8 +133,8 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            await jenkinsClient.waitForBuildToFinish(repositoryName, 1);
-        }, 240000);
+            await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 240000);
+        }, 300000);
 
 
         /**
@@ -152,8 +151,8 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            await jenkinsClient.waitForBuildToFinish(repositoryName, 2);
-        }, 240000);
+            await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 240000);
+        }, 300000);
 
         /**
          * Obtain the openshift Route for the component and verify that the previous builded image was synced in the cluster and deployed in development environment

--- a/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
@@ -133,8 +133,8 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 240000);
-        }, 300000);
+            await jenkinsClient.waitForBuildToFinish(repositoryName, 1, 540000);
+        }, 600000);
 
 
         /**
@@ -151,8 +151,8 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
             await jenkinsClient.buildJenkinsJob(repositoryName);
             console.log('Waiting for the build to start...');
             await new Promise(resolve => setTimeout(resolve, 5000));
-            await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 240000);
-        }, 300000);
+            await jenkinsClient.waitForBuildToFinish(repositoryName, 2, 540000);
+        }, 600000);
 
         /**
          * Obtain the openshift Route for the component and verify that the previous builded image was synced in the cluster and deployed in development environment


### PR DESCRIPTION
* increased timeouts for jenkins job runtime (jobs often took longer when run in batch even though they finished succesfully)
* Reworked `waitForBuildToFinish`  method to be an actiwe wait for job finishing
* Reworked argocd script execution to be synced.
* Removed `jest.retryTimes(2)` as it is not needed IMO because of the rework of `waitForBuildToFinish` (that's the place where the test usually failed for me and succeeded on the second try)