### PR TITLE
Changed "git_repo" to "repo" because job-spec changed the property name

### DIFF
--- a/integration-tests/tasks/rhtap-e2e.yaml
+++ b/integration-tests/tasks/rhtap-e2e.yaml
@@ -45,7 +45,7 @@ spec:
 
         echo "[DEBUG] JOB_SPEC: $JOB_SPEC"
 
-        export GIT_REPO="$(echo "$JOB_SPEC" | jq -r '.git.git_repo')"
+        export GIT_REPO="$(echo "$JOB_SPEC" | jq -r '.git.repo')"
         echo "[INFO] GIT_REPO is set to $GIT_REPO"
 
         if [ -z "$GIT_REPO" ]; then


### PR DESCRIPTION
The following is the latest structure of last git_repo, ".git.git_repo" is changed to ".git.repo". This will fix the CI failure of https://github.com/redhat-appstudio/rhtap-cli/pull/324
```
[e2e-test]     "git": {
[e2e-test]         "pull_request_number": 324,
[e2e-test]         "pull_request_author": "rhopp",
[e2e-test]         "org": "redhat-appstudio",
[e2e-test]         "repo": "rhtap-cli",
[e2e-test]         "commit_sha": "c2b4a0bfe3a9d050e6c21bf330a61be9778d5dc8",
[e2e-test]         "event_type": "pull_request",
[e2e-test]         "source_repo_url": "https://github.com/rhopp/rhtap-cli",
[e2e-test]         "source_repo_org": "rhopp",
[e2e-test]         "source_repo_branch": "RHTAP_2558",
[e2e-test]         "url": "https://github.com/rhopp/rhtap-cli",
[e2e-test]         "revision": "c2b4a0bfe3a9d050e6c21bf330a61be9778d5dc8"
[e2e-test]     }
```