### PR TITLE
Support both v0.1 and v0.2 of test-metadata

### DIFF
--- a/integration-tests/tasks/rhtap-e2e.yaml
+++ b/integration-tests/tasks/rhtap-e2e.yaml
@@ -45,12 +45,17 @@ spec:
 
         echo "[DEBUG] JOB_SPEC: $JOB_SPEC"
 
-        export GIT_REPO="$(echo "$JOB_SPEC" | jq -r '.git.repo')"
+        export GIT_REPO="$(echo "$JOB_SPEC" | jq -r '.git.repo // empty')"
         echo "[INFO] GIT_REPO is set to $GIT_REPO"
 
         if [ -z "$GIT_REPO" ]; then
-          echo "[ERROR] GIT_REPO is not set in JOB_SPEC"
-          exit 1
+        # TODO - when fully switched to test-metadata v0.2, delete next 'if'
+          echo "\$JOB_SPEC \`.git.repo\` is empty. Trying \`.git.git_repo\`"
+          GIT_REPO="$(echo "$JOB_SPEC" | jq -r '.git.git_repo // empty')"
+          if [ -z "$GIT_REPO" ]; then
+            echo "[ERROR] GIT_REPO is not set in JOB_SPEC"
+            exit 1
+          fi 
         fi
 
         if [ "$GIT_REPO" = "rhtap-e2e" ]; then


### PR DESCRIPTION
Xin's PR switched rhtap-e2e task to use format from test-metadata v0.2 which breaks our current e2e tests until we switch our pipelines to use test-metadata v0.2 (for example in https://github.com/redhat-appstudio/rhtap-cli/pull/324)
This PR should support both v0.1 and v0.2 at the same time.
This PR also fixes the check for empty variable `GIT_REPO`. `jq` by default returns `null` string and thus the if `if [ -z "$GIT_REPO" ]; then` never goes in.  The `// empty` makes jq to return empty string.