### PR TITLE
Allways use rhtap quay org as we don't use quay.io now.

### DIFF
--- a/integration-tests/scripts/rhtap-e2e-runner.sh
+++ b/integration-tests/scripts/rhtap-e2e-runner.sh
@@ -16,14 +16,11 @@ export APPLICATION_ROOT_NAMESPACE="rhtap-app"
 export GITHUB_ORGANIZATION="rhtap-rhdh-qe"
 export GITLAB_ORGANIZATION="rhtap-qe"
 
-#TODO: This is a temporary workaround. We need to find a way to get the git repository name from the pipeline
-#when the pipeline is triggered from the rhtap-cli repository, which is a full installation of the rhtap-cli, the image should be pushed to the rhtap organization
-#otherwise, the image should be pushed to the rhtap_qe organization
-if [ "$GIT_REPO" = "rhtap-cli" ]; then
-    export QUAY_IMAGE_ORG="rhtap"
-else
-    export QUAY_IMAGE_ORG="rhtap_qe"
-fi
+#TODO: This is a temporary workaround as we are using only installations with quay installed in the cluster.
+# Once we add back the scenario using public quay.io instance, we need to have a logic that uses `rhtap-qe` org in case of public quay.io and `rhtap` or in case of in-cluster quay.
+export QUAY_IMAGE_ORG="rhtap"
+
+
 export IMAGE_REGISTRY="$(kubectl -n rhtap-quay get route rhtap-quay-quay -o 'jsonpath={.spec.host}')"
 export OCI_CONTAINER="${OCI_CONTAINER:-""}"
 export RED_HAT_DEVELOPER_HUB_URL="https://$(kubectl get route backstage-developer-hub -n rhtap -o jsonpath='{.spec.host}')"


### PR DESCRIPTION
The current e2e scenarios are using full installation of RHTAP (including quay instance). This changes the logic to allways use `rhtap` org as we don't use (to my best knowledge) RHTAP installation where we would use public quay.io (where we use `rhtap_qe org`).
This is quick and dirty fix and proper solution (using org based on which registry is used) should be implemented properly in https://issues.redhat.com/browse/RHTAP-3345