### PR TITLE
added default.pict to define rhtap installation when running rhtap-e2e ci

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -1,0 +1,18 @@
+# This is file used for integration tests (PR checks, post-merge checks)
+#
+
+# OCP: valid OCP versions, for example: 4.17, 4.16
+# ACS: valid values is "new" and "hosted"
+# Registry: valid values are "quay", "quay.io", "artifactory" and "nexus"
+# TPA: valid values are "new" and "hosted"
+# SCM: valid values are "github", "gitlab" and "bitbucket"
+# Pipeline: valid values are "github", "gitlab" and "bitbucket"
+# AUTH: valid values are "github" and "gitlab"
+
+OCP: 4.17
+ACS: new            
+Registry: quay.io
+TPA: new           
+SCM: github         
+Pipeline: tekton
+AUTH: github


### PR DESCRIPTION
This PR is to define rhtap installation by adding  default.pict  , which depends on https://github.com/redhat-appstudio/rhtap-cli/pull/366 and https://github.com/redhat-appstudio/rhtap-cli/pull/371