### PR TITLE
fix: switch from `quay.io` to installed quay.

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -11,7 +11,7 @@
 
 OCP: 4.17
 ACS: new            
-Registry: quay.io
+Registry: quay
 TPA: new           
 SCM: github         
 Pipeline: tekton


### PR DESCRIPTION
quay.io is not working right now. Tests are failing this every time:
```
Error: pushing image "[quay.io/rhtap/rhtap-qe:8602b57c85eaeb383a8929ef365e0a6df8cd72a9](http://quay.io/rhtap/rhtap-qe:8602b57c85eaeb383a8929ef365e0a6df8cd72a9)" to "docker://quay.io/rhtap/rhtap-qe:8602b57c85eaeb383a8929ef365e0a6df8cd72a9": trying to reuse blob sha256:486dcc5a5ac3b9d7452d24fdd0c8e1d6c1d452a5827276febe9f194ba2cb2992 at destination: checking whether a blob sha256:486dcc5a5ac3b9d7452d24fdd0c8e1d6c1d452a5827276febe9f194ba2cb2992 exists in [quay.io/rhtap/rhtap-qe](http://quay.io/rhtap/rhtap-qe): authentication required
```
This is quick fix to unblock our CI here.
For proper fix I expect we need to tell e2e tests to push to different org/repo in quay.io.