### PR TITLE
[RHTAP-4072] Fixes rh-syft, ACS scan check for Gitlab

### DIFF
--- a/tests/gpts/github/test-config/github_advanced_scenario.ts
+++ b/tests/gpts/github/test-config/github_advanced_scenario.ts
@@ -225,15 +225,15 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
         * if failed to figure out the image path ,return pod yaml for reference
         */
         it(`Check ${gptTemplate} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace, 'push');
             expect(result).toBe(true);
         }, 900000);
 
         /**
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
-        it(`Check if ACS Scan is successful for ${gptTemplate}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
+        it(`Check if ACS Scan is successful for ${gptTemplate}`, async ()=> {
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace, 'push');
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);

--- a/tests/gpts/github/test-config/github_positive_suite.ts
+++ b/tests/gpts/github/test-config/github_positive_suite.ts
@@ -172,7 +172,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
          * if failed to figure out the image path ,return pod yaml for reference
          */
         it(`Check ${gptTemplate} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace, 'push');
             expect(result).toBe(true);
         }, 900000);
 
@@ -180,7 +180,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
         it(`Check if ACS Scan is successful for ${gptTemplate}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace, 'push');
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);

--- a/tests/gpts/gitlab/suites-config/gitlab_advanced_suite.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_advanced_suite.ts
@@ -167,24 +167,6 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
         }, 900000);
 
         /**
-        * Check if the pipelinerun yaml has the rh-syft image path mentioned
-        * if failed to figure out the image path ,return pod yaml for reference
-        */
-        it(`Check ${softwareTemplateName} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
-            expect(result).toBe(true);
-        }, 900000);
-
-        /**
-            * verify if the ACS Scan is successfully done from the logs of task steps
-        */
-        it(`Check if ACS Scan is successful for ${softwareTemplateName}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
-            expect(result).toBe(true);
-            console.log("Verified as ACS Scan is Successful");
-        }, 900000);
-
-        /**
             * Merges a merge request and waits until a pipeline run push is created in the cluster and start to wait until succeed/fail.
         */
         it(`merge merge_request for component ${softwareTemplateName} and waits until push pipelinerun finished successfully`, async () => {
@@ -207,6 +189,24 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
                 }
                 expect(finished).toBe(true);
             }
+        }, 900000);
+
+        /**
+        * Check if the pipelinerun yaml has the rh-syft image path mentioned
+        * if failed to figure out the image path ,return pod yaml for reference
+        */
+        it(`Check ${softwareTemplateName} pipelinerun yaml has the rh-syft image path`, async () => {
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace, 'Push');
+            expect(result).toBe(true);
+        }, 900000);
+
+        /**
+            * verify if the ACS Scan is successfully done from the logs of task steps
+        */
+        it(`Check if ACS Scan is successful for ${softwareTemplateName}`, async () => {
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace, 'Push');
+            expect(result).toBe(true);
+            console.log("Verified as ACS Scan is Successful");
         }, 900000);
 
         /**

--- a/tests/gpts/gitlab/suites-config/gitlab_positive_suite.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_positive_suite.ts
@@ -156,7 +156,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
          * if failed to figure out the image path ,return pod yaml for reference
          */
         it(`Check ${softwareTemplateName} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace, 'Push');
             expect(result).toBe(true);
         }, 900000);
 
@@ -164,7 +164,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
         it(`Check if ACS Scan is successful for ${softwareTemplateName}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace, 'Push');
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);


### PR DESCRIPTION
This PR adds eventType as param for PPR fetching in rh-syft and ACS check.
This change is necessary as Github and Gitlab event type strings for the same events are different.

Issue: [RHTAP-4072](https://issues.redhat.com/browse/RHTAP-4072)