### PR TITLE
feat: CI workloads have their own namespace

### DIFF
--- a/src/apis/kubernetes/kube.ts
+++ b/src/apis/kubernetes/kube.ts
@@ -242,7 +242,7 @@ export class Kubernetes extends Utils {
     /**
      * Accepts the pipelinerun name and fetches pipelinerun yaml output.
      * Returns the yaml value in the variable 'doc'
-     * @param {string} namespace - The namespace default value is rhtap-app-development.
+     * @param {string} namespace - The namespace default value is rhtap-app-ci.
      * @param {string} name - The name of the pipelinerun
      * @throws This function does not throw directly, but may throw errors during API calls or retries.
      */
@@ -445,7 +445,7 @@ export class Kubernetes extends Utils {
     * Gets cosign public key.
     */
     public async getCosignPublicKey(): Promise<string> {
-        return this.getSecretPartialName("rhtap-app-development", "cosign-pub", "cosign.pub", false);
+        return this.getSecretPartialName("rhtap-app-ci", "cosign-pub", "cosign.pub", false);
     }
 
     /**

--- a/src/utils/test.utils.ts
+++ b/src/utils/test.utils.ts
@@ -184,7 +184,7 @@ export async function checkComponentSyncedInArgoAndRouteIsWorking(kubeClient: Ku
     expect(await waitForStringInPageContent(`https://${componentRoute}`, stringOnRoute, 120000)).toBe(true);
 }
 
-export async function checkEnvVariablesGitLab(componentRootNamespace: string, gitLabOrganization: string, quayImageOrg: string, developmentNamespace: string, kubeClient: Kubernetes) {
+export async function checkEnvVariablesGitLab(componentRootNamespace: string, gitLabOrganization: string, quayImageOrg: string, ciNamespace: string, kubeClient: Kubernetes) {
     if (componentRootNamespace === '') {
         throw new Error("The 'APPLICATION_ROOT_NAMESPACE' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
@@ -197,12 +197,12 @@ export async function checkEnvVariablesGitLab(componentRootNamespace: string, gi
         throw new Error("The 'QUAY_IMAGE_ORG' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
 
-    if (!await kubeClient.namespaceExists(developmentNamespace)) {
-        throw new Error(`The development namespace was not created. Make sure you have created ${developmentNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
+    if (!await kubeClient.namespaceExists(ciNamespace)) {
+        throw new Error(`The CI namespace was not created. Make sure ${ciNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
     }
 }
 
-export async function checkEnvVariablesGitHub(componentRootNamespace: string, githubOrganization: string, quayImageOrg: string, developmentNamespace: string, kubeClient: Kubernetes) {
+export async function checkEnvVariablesGitHub(componentRootNamespace: string, githubOrganization: string, quayImageOrg: string, ciNamespace: string, kubeClient: Kubernetes) {
     if (componentRootNamespace === '') {
         throw new Error("The 'APPLICATION_ROOT_NAMESPACE' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
@@ -215,14 +215,14 @@ export async function checkEnvVariablesGitHub(componentRootNamespace: string, gi
         throw new Error("The 'QUAY_IMAGE_ORG' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
 
-    const namespaceExists = await kubeClient.namespaceExists(developmentNamespace);
+    const namespaceExists = await kubeClient.namespaceExists(ciNamespace);
 
     if (!namespaceExists) {
-        throw new Error(`The development namespace was not created. Make sure you have created ${developmentNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
+        throw new Error(`The CI namespace was not created. Make sure ${ciNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
     }
 }
 
-export async function checkEnvVariablesBitbucket(componentRootNamespace: string, bitbucketWorkspace: string, bitbucketProject: string, quayImageOrg: string, developmentNamespace: string, kubeClient: Kubernetes) {
+export async function checkEnvVariablesBitbucket(componentRootNamespace: string, bitbucketWorkspace: string, bitbucketProject: string, quayImageOrg: string, ciNamespace: string, kubeClient: Kubernetes) {
     if (componentRootNamespace === '') {
         throw new Error("The 'APPLICATION_ROOT_NAMESPACE' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
@@ -239,10 +239,10 @@ export async function checkEnvVariablesBitbucket(componentRootNamespace: string,
         throw new Error("The 'QUAY_IMAGE_ORG' environment variable is not set. Please ensure that the environment variable is defined properly or you have cluster connection.");
     }
 
-    const namespaceExists = await kubeClient.namespaceExists(developmentNamespace);
+    const namespaceExists = await kubeClient.namespaceExists(ciNamespace);
 
     if (!namespaceExists) {
-        throw new Error(`The development namespace was not created. Make sure you have created ${developmentNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
+        throw new Error(`The CI namespace was not created. Make sure ${ciNamespace} is created and all secrets are created. Example: 'https://github.com/jduimovich/rhdh/blob/main/default-rhtap-ns-configure'`);
     }
 
 }
@@ -366,17 +366,17 @@ export async function waitForJenkinsJobToFinish(jenkinsClient: JenkinsCI, jobNam
  * if the scan was successful.
  * 
  * @param {string} repositoryName - The name of the repository for which the pipeline run is triggered.
- * @param {string} developmentNamespace - The Kubernetes namespace where the development resources (including the ACS scan pod) are deployed.
+ * @param {string} ciNamespace - The Kubernetes namespace where the CI resources (including the ACS scan pod) are deployed.
  * @returns {Promise<boolean>} A Promise that resolves to `true` if the ACS scan was successful, or `false` if not.
  * @throws {Error} If the pipeline run cannot be found or if there is an error interacting with the Kubernetes API.
  * 
  */
-export async function checkIfAcsScanIsPass(kubeClient: Kubernetes, repositoryName: string, developmentNamespace: string):Promise<boolean> {
+export async function checkIfAcsScanIsPass(kubeClient: Kubernetes, repositoryName: string, ciNamespace: string):Promise<boolean> {
     const pipelineRun = await kubeClient.getPipelineRunByRepository(repositoryName, 'push');
     if (pipelineRun?.metadata?.name) {
         const podName: string = pipelineRun.metadata.name + '-acs-image-scan-pod';
         // Read the logs from the related container
-        const podLogs: unknown = await kubeClient.readContainerLogs(podName, developmentNamespace, 'step-rox-image-scan');
+        const podLogs: unknown = await kubeClient.readContainerLogs(podName, ciNamespace, 'step-rox-image-scan');
         if (typeof podLogs !== "string") {
             throw new Error(`Failed to retrieve container logs: Expected a string but got ${typeof podLogs}`);
         }
@@ -421,17 +421,17 @@ export async function waitForGitLabCIPipelineToFinish(gitLabProvider: GitLabProv
  * If not found,return pod yaml for reference
  * 
  * @param {string} repositoryName - The name of the repository for which the pipeline run is triggered.
- * @param {string} developmentNamespace - The Kubernetes namespace where the development resources (including the ACS scan pod) are deployed.
+ * @param {string} ciNamespace - The Kubernetes namespace where the CI resources (including the ACS scan pod) are deployed.
  * @returns {Promise<boolean>} A Promise that resolves to `true` if image verification is successful, or `false` if not.
  * @throws {Error} If the pipeline run cannot be found or if there is an error interacting with the Kubernetes API.
  * 
  */
-export async function verifySyftImagePath(kubeClient: Kubernetes, repositoryName: string, developmentNamespace: string): Promise<boolean> {
+export async function verifySyftImagePath(kubeClient: Kubernetes, repositoryName: string, ciNamespace: string): Promise<boolean> {
     const pipelineRun = await kubeClient.getPipelineRunByRepository(repositoryName, 'push');
     let result = true;
     if (pipelineRun?.metadata?.name) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const doc: any = await kubeClient.pipelinerunfromName(pipelineRun.metadata.name, developmentNamespace);
+        const doc: any = await kubeClient.pipelinerunfromName(pipelineRun.metadata.name, ciNamespace);
         const index = doc.spec.pipelineSpec.tasks.findIndex((item: { name: string; }) => item.name === "build-container");
         const regex = new RegExp("registry.redhat.io/rh-syft-tech-preview/syft-rhel9", 'i');
         const imageIndex: number = (doc.spec.pipelineSpec.tasks[index].taskSpec.steps.findIndex((item: { image: string; }) => regex.test(item.image)));
@@ -441,7 +441,7 @@ export async function verifySyftImagePath(kubeClient: Kubernetes, repositoryName
         else {
             const podName: string = pipelineRun.metadata.name + '-build-container-pod';
             // Read the yaml of the given pod
-            const podYaml = await kubeClient.getPodYaml(podName, developmentNamespace);
+            const podYaml = await kubeClient.getPodYaml(podName, ciNamespace);
             console.log(`The image path not found.The build-container pod yaml is : \n${podYaml}`);
             result = false;
         }

--- a/tests/gpts/github/test-config/github_actions_suite.ts
+++ b/tests/gpts/github/test-config/github_actions_suite.ts
@@ -18,8 +18,9 @@ export const gitHubActionsBasicGoldenPathTemplateTests = (gptTemplate: string, s
         jest.retryTimes(2);
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentEnvironmentName = 'development';
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
 
         const githubOrganization = process.env.GITHUB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${gptTemplate}`;
@@ -48,7 +49,7 @@ export const gitHubActionsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             gitHubClient = await getGitHubClient(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
 
-            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**

--- a/tests/gpts/github/test-config/github_advanced_jenkins.ts
+++ b/tests/gpts/github/test-config/github_advanced_jenkins.ts
@@ -27,6 +27,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
         const productionEnvironmentName = 'prod';
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
         const stageNamespace = `${componentRootNamespace}-${stagingEnvironmentName}`;
         const prodNamespace = `${componentRootNamespace}-${productionEnvironmentName}`;
@@ -62,7 +63,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
             jenkinsClient = await getJenkinsCI(kubeClient);
             gitHubClient = await getGitHubClient(kubeClient);
 
-            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -180,7 +181,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
         }, 120000);
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Trigger job and wait for ${gptTemplate} jenkins job to finish`, async () => {
             await new Promise(resolve => setTimeout(resolve, 5000));
@@ -197,7 +198,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
         }, 900000);
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Trigger job and wait for ${gptTemplate} jenkins job to finish`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName + "-gitops");
@@ -237,7 +238,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
 
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Wait for ${gptTemplate} jenkins job to finish for promotion from development to stage`, async () => {
             await new Promise(resolve => setTimeout(resolve, 5000));
@@ -283,7 +284,7 @@ export const gitHubJenkinsPromotionTemplateTests = (gptTemplate: string, stringO
         }, 120000);
 
         /**
-        * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+        * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
         */
         it(`Trigger job and wait for ${gptTemplate} jenkins job to finish promotion pipeline for production environment`, async () => {
             await new Promise(resolve => setTimeout(resolve, 5000));

--- a/tests/gpts/github/test-config/github_advanced_scenario.ts
+++ b/tests/gpts/github/test-config/github_advanced_scenario.ts
@@ -35,6 +35,7 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
         const productionEnvironmentName = 'prod';
         const quayImageName = "rhtap-qe";
 
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
         const stageNamespace = `${componentRootNamespace}-${stagingEnvironmentName}`;
         const prodNamespace = `${componentRootNamespace}-${productionEnvironmentName}`;
@@ -67,7 +68,7 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
             gitHubClient = await getGitHubClient(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
 
-            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -177,12 +178,12 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -207,12 +208,12 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -224,7 +225,7 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
         * if failed to figure out the image path ,return pod yaml for reference
         */
         it(`Check ${gptTemplate} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, developmentNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
         }, 900000);
 
@@ -232,7 +233,7 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
         it(`Check if ACS Scan is successful for ${gptTemplate}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, developmentNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);
@@ -285,12 +286,12 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -352,12 +353,12 @@ export const githubSoftwareTemplatesAdvancedScenarios = (gptTemplate: string) =>
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);

--- a/tests/gpts/github/test-config/github_positive_suite.ts
+++ b/tests/gpts/github/test-config/github_positive_suite.ts
@@ -20,7 +20,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
         jest.retryTimes(2);
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
 
         const githubOrganization = process.env.GITHUB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${gptTemplate}`;
@@ -47,7 +47,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
             gitHubClient = await getGitHubClient(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
 
-            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -155,12 +155,12 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -172,7 +172,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
          * if failed to figure out the image path ,return pod yaml for reference
          */
         it(`Check ${gptTemplate} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, developmentNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
         }, 900000);
 
@@ -180,7 +180,7 @@ export const gitHubBasicGoldenPathTemplateTests = (gptTemplate: string) => {
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
         it(`Check if ACS Scan is successful for ${gptTemplate}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, developmentNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);

--- a/tests/gpts/github/test-config/github_suite_jenkins.ts
+++ b/tests/gpts/github/test-config/github_suite_jenkins.ts
@@ -22,8 +22,9 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
     describe(`Red Hat Trusted Application Pipeline ${gptTemplate} GPT tests GitHub provider with public/private image registry`, () => {
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
         const developmentEnvironmentName = 'development';
+        const ciNamespace = `${componentRootNamespace}-ci`;
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
 
         const githubOrganization = process.env.GITHUB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${gptTemplate}`;
@@ -54,7 +55,7 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
             backstageClient = await getDeveloperHubClient(kubeClient);
             jenkinsClient = await getJenkinsCI(kubeClient);
 
-            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitHub(componentRootNamespace, githubOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -164,7 +165,7 @@ export const gitHubJenkinsBasicGoldenPathTemplateTests = (gptTemplate: string, s
         }, 120000);
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Trigger job and wait for ${gptTemplate} jenkins job to finish`, async () => {
             new Utils().sleep(5000);

--- a/tests/gpts/gitlab/suites-config/gitlab_advanced_jenkins.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_advanced_jenkins.ts
@@ -41,6 +41,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
         const developmentEnvironmentName = 'development';
         const stagingEnvironmentName = 'stage';
         const productionEnvironmentName = 'prod';
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
         const stageNamespace = `${componentRootNamespace}-${stagingEnvironmentName}`;
         const prodNamespace = `${componentRootNamespace}-${productionEnvironmentName}`;
@@ -62,7 +63,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
             backstageClient = await getDeveloperHubClient(kubeClient);
             jenkinsClient = await getJenkinsCI(kubeClient);
             gitLabProvider = await getGitLabProvider(kubeClient);
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, imageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, imageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -174,7 +175,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
         }, 120000);
 
         /**
-        * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+        * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
         */
         it(`Trigger job and wait for ${softwareTemplateName} jenkins job to finish`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName);
@@ -194,7 +195,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
 
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Trigger job and wait for ${softwareTemplateName} GitOps jenkins job to finish`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName + "-gitops");
@@ -224,7 +225,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
 
 
         /**
-         * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+         * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
          */
         it(`Wait for ${softwareTemplateName} jenkins job to finish for promotion from development to stage`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName + "-gitops");
@@ -264,7 +265,7 @@ export const gitLabJenkinsAdvancedTests = (softwareTemplateName: string, stringO
         }, 120000);
 
         /**
-        * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+        * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
         */
         it(`Trigger job and wait for ${softwareTemplateName} jenkins job to finish promotion pipeline for production environment`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName + "-gitops");

--- a/tests/gpts/gitlab/suites-config/gitlab_advanced_suite.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_advanced_suite.ts
@@ -46,7 +46,8 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
         const quayImageName = "rhtap-qe";
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
         const stageNamespace = `${componentRootNamespace}-${stagingEnvironmentName}`;
         const prodNamespace = `${componentRootNamespace}-${productionEnvironmentName}`;
 
@@ -65,7 +66,7 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             const componentRoute = await kubeClient.getOpenshiftRoute('pipelines-as-code-controller', 'openshift-pipelines');
             pipelineAsCodeRoute = `https://${componentRoute}`;
 
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -153,12 +154,12 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -170,7 +171,7 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
         * if failed to figure out the image path ,return pod yaml for reference
         */
         it(`Check ${softwareTemplateName} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, developmentNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
         }, 900000);
 
@@ -178,7 +179,7 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             * verify if the ACS Scan is successfully done from the logs of task steps
         */
         it(`Check if ACS Scan is successful for ${softwareTemplateName}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, developmentNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);
@@ -196,12 +197,12 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -240,12 +241,12 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -290,12 +291,12 @@ export const gitLabSoftwareTemplatesAdvancedScenarios = (softwareTemplateName: s
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);

--- a/tests/gpts/gitlab/suites-config/gitlab_gitlabci_advanced.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_gitlabci_advanced.ts
@@ -46,7 +46,8 @@ export const gitLabProviderGitLabCIWithPromotionTests = (softwareTemplateName: s
         const stagingEnvironmentName = 'stage';
         const productionEnvironmentName = 'prod';
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
         const stageNamespace = `${componentRootNamespace}-${stagingEnvironmentName}`;
         const prodNamespace = `${componentRootNamespace}-${productionEnvironmentName}`;
 
@@ -64,7 +65,7 @@ export const gitLabProviderGitLabCIWithPromotionTests = (softwareTemplateName: s
             gitLabProvider = await getGitLabProvider(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
 
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, imageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, imageOrg, ciNamespace, kubeClient);
         });
 
         /**

--- a/tests/gpts/gitlab/suites-config/gitlab_gitlabci_suite.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_gitlabci_suite.ts
@@ -31,8 +31,9 @@ export const gitLabProviderGitLabCITests = (softwareTemplateName: string, string
         let RHTAPGitopsNamespace: string;
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentEnvironmentName = 'development';
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
 
         const gitLabOrganization = process.env.GITLAB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${softwareTemplateName}`;
@@ -48,7 +49,7 @@ export const gitLabProviderGitLabCITests = (softwareTemplateName: string, string
             gitLabProvider = await getGitLabProvider(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
 
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**

--- a/tests/gpts/gitlab/suites-config/gitlab_positive_suite.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_positive_suite.ts
@@ -30,7 +30,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
         let RHTAPGitopsNamespace: string;
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
 
         const gitLabOrganization = process.env.GITLAB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${softwareTemplateName}`;
@@ -49,7 +49,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
             const componentRoute = await kubeClient.getOpenshiftRoute('pipelines-as-code-controller', 'openshift-pipelines');
             pipelineAsCodeRoute = `https://${componentRoute}`;
 
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -138,12 +138,12 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
             }
 
             if (pipelineRun && pipelineRun.metadata && pipelineRun.metadata.name) {
-                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, developmentNamespace, 900000);
+                const finished = await kubeClient.waitPipelineRunToBeFinished(pipelineRun.metadata.name, ciNamespace, 900000);
                 const tskRuns = await kubeClient.getTaskRunsFromPipelineRun(pipelineRun.metadata.name);
 
                 for (const iterator of tskRuns) {
                     if (iterator.status && iterator.status.podName) {
-                        await kubeClient.readNamespacedPodLog(iterator.status.podName, developmentNamespace);
+                        await kubeClient.readNamespacedPodLog(iterator.status.podName, ciNamespace);
                     }
                 }
                 expect(finished).toBe(true);
@@ -156,7 +156,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
          * if failed to figure out the image path ,return pod yaml for reference
          */
         it(`Check ${softwareTemplateName} pipelinerun yaml has the rh-syft image path`, async () => {
-            const result = await verifySyftImagePath(kubeClient, repositoryName, developmentNamespace);
+            const result = await verifySyftImagePath(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
         }, 900000);
 
@@ -164,7 +164,7 @@ export const gitLabProviderBasicTests = (softwareTemplateName: string) => {
          * verify if the ACS Scan is successfully done from the logs of task steps
          */
         it(`Check if ACS Scan is successful for ${softwareTemplateName}`, async () => {
-            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, developmentNamespace);
+            const result = await checkIfAcsScanIsPass(kubeClient, repositoryName, ciNamespace);
             expect(result).toBe(true);
             console.log("Verified as ACS Scan is Successful");
         }, 900000);

--- a/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
+++ b/tests/gpts/gitlab/suites-config/gitlab_suite_jenkins.ts
@@ -34,8 +34,9 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
         let RHTAPGitopsNamespace: string;
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
-        const developmentNamespace = `${componentRootNamespace}-development`;
+        const ciNamespace = `${componentRootNamespace}-ci`;
         const developmentEnvironmentName = 'development';
+        const developmentNamespace = `${componentRootNamespace}-${developmentEnvironmentName}`;
 
         const gitLabOrganization = process.env.GITLAB_ORGANIZATION || '';
         const repositoryName = `${generateRandomChars(9)}-${softwareTemplateName}`;
@@ -52,7 +53,7 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
             backstageClient = await getDeveloperHubClient(kubeClient);
             jenkinsClient = await getJenkinsCI(kubeClient);
             gitLabProvider = await getGitLabProvider(kubeClient);
-            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, developmentNamespace, kubeClient);
+            await checkEnvVariablesGitLab(componentRootNamespace, gitLabOrganization, quayImageOrg, ciNamespace, kubeClient);
         });
 
         /**
@@ -146,7 +147,7 @@ export const gitLabJenkinsBasicTests = (softwareTemplateName: string, stringOnRo
         }, 120000);
 
         /**
-        * Trigger and wait for Jenkins job to finish(it will also run deplyment pipeline)
+        * Trigger and wait for Jenkins job to finish(it will also run deployment pipeline)
         */
         it(`Trigger job and wait for ${softwareTemplateName} jenkins job to finish`, async () => {
             await jenkinsClient.buildJenkinsJob(repositoryName);


### PR DESCRIPTION
There is no reason for the development application to run in a namespace with the extra secrets needed by the ci.

This split provides better segregation of information and makes the development namespace identical to the other deployment namespaces in term of configuration.

cf: https://github.com/redhat-appstudio/rhtap-cli/pull/459