### PR TITLE
Set env vars as variables in GitHub Actions

### DIFF
--- a/src/utils/test.utils.ts
+++ b/src/utils/test.utils.ts
@@ -511,23 +511,28 @@ export async function setSecretsForJenkinsInFolderForTPA(jenkinsClient: JenkinsC
     await jenkinsClient.createCredentialsInFolder("GLOBAL", "TRUSTIFICATION_SUPPORTED_CYCLONEDX_VERSION", await kubeClient.getTTrustificationSupportedCycloneDXVersion(await getRHTAPRootNamespace()), folderName);
 }
 
-export async function setGitHubActionSecrets(gitHubClient: GitHubProvider, kubeClient: Kubernetes, githubOrganization: string, repositoryName: string, imageRegistry: string, rhtapRootNamespace: string) {
+export async function setGitHubActionSecrets(gitHubClient: GitHubProvider, kubeClient: Kubernetes, githubOrganization: string, repositoryName: string) {
     await gitHubClient.setGitHubSecrets(githubOrganization, repositoryName, {
-        "IMAGE_REGISTRY": imageRegistry,
         "ROX_API_TOKEN": await kubeClient.getACSToken(await getRHTAPRootNamespace()),
-        "ROX_CENTRAL_ENDPOINT": await kubeClient.getACSEndpoint(await getRHTAPRootNamespace()),
         "GITOPS_AUTH_PASSWORD": process.env.GITHUB_TOKEN || '',
-        "IMAGE_REGISTRY_USER": process.env.IMAGE_REGISTRY_USERNAME || '',
         "IMAGE_REGISTRY_PASSWORD": process.env.IMAGE_REGISTRY_PASSWORD || '',
         "COSIGN_SECRET_PASSWORD": await getCosignPassword(kubeClient),
         "COSIGN_SECRET_KEY": await getCosignPrivateKey(kubeClient),
+        "TRUSTIFICATION_OIDC_CLIENT_SECRET": await kubeClient.getTTrustificationClientSecret(await getRHTAPRootNamespace()),
+    });
+}
+
+export async function setGitHubActionVariables(gitHubClient: GitHubProvider, kubeClient: Kubernetes, githubOrganization: string, repositoryName: string, imageRegistry: string) {
+    await gitHubClient.setGitHubVariables(githubOrganization, repositoryName, {
+        "IMAGE_REGISTRY": imageRegistry,
+        "ROX_CENTRAL_ENDPOINT": await kubeClient.getACSEndpoint(await getRHTAPRootNamespace()),
+        "IMAGE_REGISTRY_USER": process.env.IMAGE_REGISTRY_USERNAME || '',
         "COSIGN_PUBLIC_KEY": await getCosignPublicKey(kubeClient),
-        "REKOR_HOST": await kubeClient.getRekorServerUrl(rhtapRootNamespace) || '',
-        "TUF_MIRROR": await kubeClient.getTUFUrl(rhtapRootNamespace) || '',
+        "REKOR_HOST": await kubeClient.getRekorServerUrl(await getRHTAPRootNamespace()) || '',
+        "TUF_MIRROR": await kubeClient.getTUFUrl(await getRHTAPRootNamespace()) || '',
         "TRUSTIFICATION_BOMBASTIC_API_URL": await kubeClient.getTTrustificationBombasticApiUrl(await getRHTAPRootNamespace()),
         "TRUSTIFICATION_OIDC_ISSUER_URL":  await kubeClient.getTTrustificationOidcIssuerUrl(await getRHTAPRootNamespace()),
         "TRUSTIFICATION_OIDC_CLIENT_ID": await kubeClient.getTTrustificationClientId(await getRHTAPRootNamespace()),
-        "TRUSTIFICATION_OIDC_CLIENT_SECRET": await kubeClient.getTTrustificationClientSecret(await getRHTAPRootNamespace()),
         "TRUSTIFICATION_SUPPORTED_CYCLONEDX_VERSION": await kubeClient.getTTrustificationSupportedCycloneDXVersion(await getRHTAPRootNamespace()),
     });
 }

--- a/tests/gpts/github/test-config/github_actions_suite.ts
+++ b/tests/gpts/github/test-config/github_actions_suite.ts
@@ -4,7 +4,18 @@ import { TaskIdReponse } from '../../../../src/apis/backstage/types';
 import { generateRandomChars } from '../../../../src/utils/generator';
 import { GitHubProvider } from "../../../../src/apis/scm-providers/github";
 import { Kubernetes } from "../../../../src/apis/kubernetes/kube";
-import { checkComponentSyncedInArgoAndRouteIsWorking, checkEnvVariablesGitHub, cleanAfterTestGitHub, createTaskCreatorOptionsGitHub, getDeveloperHubClient, getGitHubClient, getRHTAPGitopsNamespace, getRHTAPRootNamespace, setGitHubActionSecrets, waitForComponentCreation} from "../../../../src/utils/test.utils";
+import {
+    checkComponentSyncedInArgoAndRouteIsWorking,
+    checkEnvVariablesGitHub,
+    cleanAfterTestGitHub,
+    createTaskCreatorOptionsGitHub,
+    getDeveloperHubClient,
+    getGitHubClient,
+    getRHTAPGitopsNamespace,
+    setGitHubActionSecrets,
+    setGitHubActionVariables,
+    waitForComponentCreation
+} from "../../../../src/utils/test.utils";
 
 /**
  * 1. Components get created in Red Hat Developer Hub
@@ -32,7 +43,6 @@ export const gitHubActionsBasicGoldenPathTemplateTests = (gptTemplate: string, s
         const imageRegistry = process.env.IMAGE_REGISTRY || 'quay.io';
 
         let RHTAPGitopsNamespace: string;
-        let RHTAPRootNamespace: string;
 
         let developerHubTask: TaskIdReponse;
         let backstageClient: DeveloperHubClient;
@@ -46,7 +56,6 @@ export const gitHubActionsBasicGoldenPathTemplateTests = (gptTemplate: string, s
         */
         beforeAll(async () => {
             RHTAPGitopsNamespace = await getRHTAPGitopsNamespace();
-            RHTAPRootNamespace = await getRHTAPRootNamespace();
             kubeClient = new Kubernetes();
             gitHubClient = await getGitHubClient(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
@@ -110,7 +119,8 @@ export const gitHubActionsBasicGoldenPathTemplateTests = (gptTemplate: string, s
          * Creates secrets for GitHub Actions Workflow
          */
         it (`creates env variables in repo`, async () => {
-            await setGitHubActionSecrets(gitHubClient, kubeClient, githubOrganization, repositoryName, imageRegistry, RHTAPRootNamespace);
+            await setGitHubActionSecrets(gitHubClient, kubeClient, githubOrganization, repositoryName);
+            await setGitHubActionVariables(gitHubClient, kubeClient, githubOrganization, repositoryName, imageRegistry);
             expect(await gitHubClient.updateWorkflowFileToEnableSecrets(githubOrganization, repositoryName, '.github/workflows/build-and-update-gitops.yml')).not.toBe(undefined);
         }, 600000);
 

--- a/tests/gpts/github/test-config/github_advanced_actions.ts
+++ b/tests/gpts/github/test-config/github_advanced_actions.ts
@@ -4,7 +4,20 @@ import { TaskIdReponse } from '../../../../src/apis/backstage/types';
 import { generateRandomChars } from '../../../../src/utils/generator';
 import { GitHubProvider } from "../../../../src/apis/scm-providers/github";
 import { Kubernetes } from "../../../../src/apis/kubernetes/kube";
-import { checkComponentSyncedInArgoAndRouteIsWorking, checkEnvVariablesGitHub, checkSBOMInTrustification, cleanAfterTestGitHub, createTaskCreatorOptionsGitHub, getDeveloperHubClient, getGitHubClient, getRHTAPGitopsNamespace, getRHTAPRootNamespace, setGitHubActionSecrets, parseSbomVersionFromLogs, waitForComponentCreation} from "../../../../src/utils/test.utils";
+import {
+    checkComponentSyncedInArgoAndRouteIsWorking,
+    checkEnvVariablesGitHub,
+    checkSBOMInTrustification,
+    cleanAfterTestGitHub,
+    createTaskCreatorOptionsGitHub,
+    getDeveloperHubClient,
+    getGitHubClient,
+    getRHTAPGitopsNamespace,
+    setGitHubActionSecrets,
+    parseSbomVersionFromLogs,
+    waitForComponentCreation,
+    setGitHubActionVariables
+} from "../../../../src/utils/test.utils";
 
 /**
  * Advanced end-to-end test scenario for Red Hat Trusted Application Pipelines:
@@ -37,7 +50,6 @@ export const githubActionsSoftwareTemplatesAdvancedScenarios = (gptTemplate: str
         let extractedBuildImage: string;
 
         let RHTAPGitopsNamespace: string;
-        let RHTAPRootNamespace: string;
 
         const componentRootNamespace = process.env.APPLICATION_ROOT_NAMESPACE || 'rhtap-app';
         const developmentEnvironmentName = 'development';
@@ -61,7 +73,6 @@ export const githubActionsSoftwareTemplatesAdvancedScenarios = (gptTemplate: str
         */
         beforeAll(async () => {
             RHTAPGitopsNamespace = await getRHTAPGitopsNamespace();
-            RHTAPRootNamespace = await getRHTAPRootNamespace();
             kubeClient = new Kubernetes();
             gitHubClient = await getGitHubClient(kubeClient);
             backstageClient = await getDeveloperHubClient(kubeClient);
@@ -135,7 +146,8 @@ export const githubActionsSoftwareTemplatesAdvancedScenarios = (gptTemplate: str
                 }
             ];
             for (const repoData of repoDict) {
-                await setGitHubActionSecrets(gitHubClient, kubeClient, githubOrganization, repoData.repoName, imageRegistry, RHTAPRootNamespace);
+                await setGitHubActionSecrets(gitHubClient, kubeClient, githubOrganization, repoData.repoName);
+                await setGitHubActionVariables(gitHubClient, kubeClient, githubOrganization, repoData.repoName, imageRegistry);
                 expect(await gitHubClient.updateWorkflowFileToEnableSecrets(githubOrganization, repoData.repoName, repoData.workflowPath)).not.toBe(undefined);
             }
 


### PR DESCRIPTION
At the moment only secrets are able to be created in rhtap-e2e. 
There is a need to set some of the environment variables as GitHub variables because they will not get masked in GitHub Actions logs and can thus be displayed to users via eyecatcher