### PR TITLE
Changes default SCM to Github

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -14,5 +14,5 @@ AUTH: gitlab
 ACS: new
 Registry: nexus
 TPA: new
-SCM: bitbucket
+SCM: github
 Pipeline: tekton


### PR DESCRIPTION
This PR changes default SCM to Github to avoid issues with Bitbucket api rate limit.