### PR TITLE
Switches pipeline to GitlabCI

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -15,4 +15,4 @@ ACS: new
 Registry: nexus
 TPA: new
 SCM: github
-Pipeline: tekton
+Pipeline: gitlabci


### PR DESCRIPTION
This PR switches pipelines from Tekton to GitlabCI to momentarily avoid failures in EC check.
Issue: https://redhat-internal.slack.com/archives/C065GQMTLN4/p1742809912696249