### PR TITLE
[RHTAP-4090] Fix for double PPR trigger in advanced GitLab scenarios

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -10,12 +10,12 @@
 # AUTH: valid values are "github" and "gitlab"
 
 OCP: 4.17
-AUTH: github
+AUTH: gitlab
 ACS: new
 Registry: nexus
 TPA: new
-SCM: github
-Pipeline: actions
+SCM: gitlab
+Pipeline: tekton
 
 # Constraints
 ## Parameter value validation. This doesn't work with the current pict docker image, we can uncomment it when we figure out it in future

--- a/src/apis/scm-providers/gitlab.ts
+++ b/src/apis/scm-providers/gitlab.ts
@@ -261,6 +261,9 @@ export class GitLabProvider extends Utils {
                 ]
             );
 
+            // Wait for GitLab to process the commit
+            await new Promise(resolve => setTimeout(resolve, 5000));
+
             const mergeRequest = await this.gitlab.MergeRequests.create(repositoryID, branchName, "main", title);
 
             console.log(`Pull request "${title}" created successfully. URL: ${mergeRequest.web_url}`);


### PR DESCRIPTION
Adds wait after commit creation in GitLab to make sure the commit is processed before MR creation.

Issue: [RHTAP-4090](https://issues.redhat.com/browse/RHTAP-4090)