### PR TITLE
fix: remove apply-tags task from e2e pull request pipeline

### DIFF
--- a/.tekton/rhtap-e2e-pull-request.yaml
+++ b/.tekton/rhtap-e2e-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtap-shared-team-tenant/rhtap-e2e/rhtap-e2e:on-pr-{{revision}}
   - name: image-expires-after
-    value: 5d
+    value: 2w
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:
@@ -415,23 +415,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: apply-tags
-      params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: ADDITIONAL_TAGS
-        value: ["latest"]
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: apply-tags
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:4973fa42a8f06238613447fbdb3d0c55eb2d718fd16f2f2591a577c29c1edb17
-        - name: kind
-          value: task
-        resolver: bundles
     - name: push-dockerfile
       params:
       - name: IMAGE


### PR DESCRIPTION
This PR removes tagging images built from PRs as `latest`. Not only this is wong, but it also caused some troubles with the 5 days retention on imager in Quay built from PRs. 
When some PR image was tagged latest and for 5 days and the `latest` tag was not moved to different image in those 5 days (meaning some other PR was built, or main branche was built), the image was deleted and the tag `latest` disappeared with it which basically caused an outage in our CI (tests rely on the `latest` tag)