### PR TITLE
fix: update GITHUB_TOKEN retrieval to include TSSC_NAMESPACE

### DIFF
--- a/integration-tests/scripts/rhtap-e2e-runner.sh
+++ b/integration-tests/scripts/rhtap-e2e-runner.sh
@@ -79,7 +79,7 @@ configure_github_variables() {
         return 0
     fi
     export GITHUB_ORGANIZATION="rhtap-rhdh-qe"
-    export GITHUB_TOKEN="$(get_secret_value "" "tssc-github-integration" "token")"
+    export GITHUB_TOKEN="$(get_secret_value "$TSSC_NAMESPACE" "tssc-github-integration" "token")"
 }   
 # Extract GitLab organization from Kubernetes secret
 configure_gitlab_variables() {


### PR DESCRIPTION
Problem introduced by 704994d25616ff2ca389bbdb841d354afaf983cf